### PR TITLE
Bump GH action versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [v2] - 2022-04-06
+
+### Changed
+
+- Updated actions from `v2` to `v3`
+- Bumped python to `3.10` for linting
+
+## [v1] - 2022-04-05
+
+### Added
+
+- Add some initial actions
+
+[Unreleased]: https://github.com/brainglobe/actions/compare/v2...HEAD
+[v2]: https://github.com/brainglobe/actions/releases/tag/v2
+[v1]: https://github.com/brainglobe/actions/releases/tag/v1

--- a/check_manifest/action.yml
+++ b/check_manifest/action.yml
@@ -5,9 +5,9 @@ description: 'Check Python package manifest'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: set PY
       shell: bash

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -5,9 +5,9 @@ description: 'Run Python linting using pre-commit'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.9
 
@@ -16,7 +16,7 @@ runs:
       run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
     - name: Cache pre-commit install
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.pythonLocation }}

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: set PY
       shell: bash

--- a/test/action.yml
+++ b/test/action.yml
@@ -10,10 +10,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ inputs.python-version }}
         


### PR DESCRIPTION
Recently, a lot of the actions have moved from v2 to v3. Also for linting may as well use `3.10`