### PR TITLE
Bump cibuildwheel version

### DIFF
--- a/build_wheels/action.yml
+++ b/build_wheels/action.yml
@@ -8,7 +8,7 @@ runs:
 
     - name: Build wheels
       # Configuration of cibuildwheel is done in pyproject.toml
-      uses: pypa/cibuildwheel@v2.4.0
+      uses: pypa/cibuildwheel@v2.12.0
 
     - name: Upload artefact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This updates the `cibuildwheel` version to the latest one. I think this is needed for https://github.com/brainglobe/cellfinder-core/issues/51, and even if not good practice to bump this to the latest minor release.

**What does this PR do?**

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
